### PR TITLE
.NET 9 & show features in test's displayname

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -10,11 +10,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-dotnet@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: |
-          8.0.100
+        global-json-file: "./global.json"
     - run: dotnet restore
     - run: dotnet build --configuration Release --no-restore
     - run: dotnet test --no-build --configuration Release --verbosity normal

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
       <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
     <PropertyGroup>
-        <LangVersion>12.0</LangVersion>
+        <LangVersion>13.0</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,9 +1,5 @@
 <Project>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,9 @@
 {
-  "sdk": {
-    "version": "8.0.100",
-    "rollForward": "latestFeature"
-  }
+    "sdk": {
+        "version": "9.0.100",
+        "rollForward": "latestFeature"
+    },
+    "msbuild-sdks": {
+        "MSTest.Sdk": "3.6.3"
+    }
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/FeatureSwitches.MSTest/FeatureSwitches.MSTest.csproj
+++ b/src/FeatureSwitches.MSTest/FeatureSwitches.MSTest.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>FeatureSwitches MSTest</Description>
     <PackageId>FeatureSwitches.MSTest</PackageId>
-    <Version>8.0.0</Version>
+    <Version>9.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,6 +11,6 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
   </ItemGroup> 
 </Project>

--- a/src/FeatureSwitches.ServiceCollection/FeatureSwitches.ServiceCollection.csproj
+++ b/src/FeatureSwitches.ServiceCollection/FeatureSwitches.ServiceCollection.csproj
@@ -3,11 +3,11 @@
   <PropertyGroup>
     <Description>ServiceCollection extensions for FeatureSwitches</Description>
     <PackageId>FeatureSwitches.ServiceCollection</PackageId>
-    <Version>8.0.0</Version>
+    <Version>9.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
-     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/FeatureSwitches/Definitions/FeatureDefinition.cs
+++ b/src/FeatureSwitches/Definitions/FeatureDefinition.cs
@@ -25,10 +25,10 @@ public sealed class FeatureDefinition
     /// <summary>
     /// Gets a list of filters.
     /// </summary>
-    public IList<FeatureFilterDefinition> Filters { get; init; } = new List<FeatureFilterDefinition>();
+    public IList<FeatureFilterDefinition> Filters { get; init; } = [];
 
     /// <summary>
     /// Gets a list of filter groups.
     /// </summary>
-    public IList<FeatureFilterGroupDefinition> FilterGroups { get; init; } = new List<FeatureFilterGroupDefinition>();
+    public IList<FeatureFilterGroupDefinition> FilterGroups { get; init; } = [];
 }

--- a/src/FeatureSwitches/Definitions/InMemoryFeatureDefinitionProvider.cs
+++ b/src/FeatureSwitches/Definitions/InMemoryFeatureDefinitionProvider.cs
@@ -201,7 +201,7 @@ public sealed class InMemoryFeatureDefinitionProvider : IFeatureDefinitionProvid
     /// <returns>A list of feature definitions.</returns>
     public IList<FeatureDefinition> Save()
     {
-        return this.featureSwitches.Values.ToList();
+        return [.. this.featureSwitches.Values];
     }
 
     /// <summary>

--- a/src/FeatureSwitches/FeatureSwitches.csproj
+++ b/src/FeatureSwitches/FeatureSwitches.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Simple feature management for .NET</Description>
     <PackageId>FeatureSwitches</PackageId>
-    <Version>8.0.0</Version>
+    <Version>9.0.0</Version>
   </PropertyGroup>
 
 </Project>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -12,6 +12,8 @@
           test code.
         [CA1303: Do not pass literals as localized parameters] 
           reasoning: test projects won't use translations
+        [CA1515: make type internal]
+          reasoning: tests need public classes in order to be found
         [CA1707: Remove the underscores from member name]
           reasoning: ok for test names.
         [CA1819: Properties should not return arrays]
@@ -21,7 +23,7 @@
         [CA2227: Change property to be read-only by removing property setter]
           test code.
     -->
-    <NoWarn>$(NoWarn);CA1034;CA1303;CA1707;CA1819;CA2007;CA2227;SA0001</NoWarn>
+    <NoWarn>$(NoWarn);CA1034;CA1303;CA1515;CA1707;CA1819;CA2007;CA2227;SA0001</NoWarn>
   </PropertyGroup>
 
 </Project>

--- a/test/FeatureSwitches.Test/FeatureSwitches.Test.csproj
+++ b/test/FeatureSwitches.Test/FeatureSwitches.Test.csproj
@@ -1,13 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="MSTest.Sdk">
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/FeatureSwitches.Test/IntegrationTest/FeatureServiceIntegrationTest.cs
+++ b/test/FeatureSwitches.Test/IntegrationTest/FeatureServiceIntegrationTest.cs
@@ -346,13 +346,16 @@ public sealed class FeatureServiceIntegrationTest
         var featureService = this.sp.GetRequiredService<FeatureService>();
         SetCurrentCustomer("A");
         var variation = await featureService.GetValue<TestVariation>("FeatureA");
-        Assert.AreEqual(Color.Gray, variation?.Color);
+        Assert.IsNotNull(variation);
+        Assert.AreEqual(Color.Gray, variation.Color);
         SetCurrentCustomer("B");
         variation = await featureService.GetValue<TestVariation>("FeatureA");
-        Assert.AreEqual(Color.White, variation?.Color);
+        Assert.IsNotNull(variation);
+        Assert.AreEqual(Color.White, variation.Color);
         SetCurrentCustomer("C");
         variation = await featureService.GetValue<TestVariation>("FeatureA");
-        Assert.AreEqual(Color.Black, variation?.Color);
+        Assert.IsNotNull(variation);
+        Assert.AreEqual(Color.Black, variation.Color);
     }
 
     [TestMethod]
@@ -472,13 +475,13 @@ public sealed class FeatureServiceIntegrationTest
         var featureService = this.sp.GetRequiredService<FeatureService>();
         var features = await featureService.GetFeatures();
         Assert.AreEqual(2, features.Length);
-        Assert.AreEqual(features[0], "FeatureA");
-        Assert.AreEqual(features[1], "FeatureB");
+        Assert.AreEqual("FeatureA", features[0]);
+        Assert.AreEqual("FeatureB", features[1]);
     }
 
     private static void SetCurrentCustomer(string name)
     {
-        Thread.CurrentPrincipal = new ClaimsPrincipal(new ClaimsIdentity(new Claim[] { new(ClaimTypes.Name, name) }));
+        Thread.CurrentPrincipal = new ClaimsPrincipal(new ClaimsIdentity([new(ClaimTypes.Name, name)]));
     }
 
     private struct StructVariation

--- a/test/FeatureSwitches.Test/MSTest/FeatureTestMethodAttributeTest.cs
+++ b/test/FeatureSwitches.Test/MSTest/FeatureTestMethodAttributeTest.cs
@@ -15,7 +15,7 @@ public sealed class FeatureTestMethodAttributeTest
         var attr = new FeatureTestMethodAttribute(onOff: "A");
 
         var testMethod = new MockTestMethod(this.TestContext);
-        attr.Execute(testMethod);
+        var testResults = attr.Execute(testMethod);
 
         Assert.AreEqual(2, testMethod.Executions.Count);
 
@@ -30,6 +30,10 @@ public sealed class FeatureTestMethodAttributeTest
         Assert.AreEqual(true, testMethod.Executions[1].Features[0].IsOn);
         Assert.AreEqual(true, testMethod.Executions[1].Features[0].OnValue);
         Assert.AreEqual(false, testMethod.Executions[1].Features[0].OffValue);
+
+        Assert.AreEqual(2, testResults.Length);
+        Assert.AreEqual($"{nameof(this.Single_feature_on_off)} (A: off)", testResults[0].DisplayName);
+        Assert.AreEqual($"{nameof(this.Single_feature_on_off)} (A: on)", testResults[1].DisplayName);
     }
 
     [TestMethod]
@@ -38,7 +42,7 @@ public sealed class FeatureTestMethodAttributeTest
         var attr = new FeatureTestMethodAttribute(onOff: "A,B");
 
         var testMethod = new MockTestMethod(this.TestContext);
-        attr.Execute(testMethod);
+        var testResults = attr.Execute(testMethod);
 
         Assert.AreEqual(4, testMethod.Executions.Count);
 
@@ -69,6 +73,12 @@ public sealed class FeatureTestMethodAttributeTest
         Assert.AreEqual(true, testMethod.Executions[3].Features[0].IsOn);
         Assert.AreEqual("B", testMethod.Executions[3].Features[1].Name);
         Assert.AreEqual(true, testMethod.Executions[3].Features[1].IsOn);
+
+        Assert.AreEqual(4, testResults.Length);
+        Assert.AreEqual($"{nameof(this.Two_features_on_off)} (A: off, B: off)", testResults[0].DisplayName);
+        Assert.AreEqual($"{nameof(this.Two_features_on_off)} (A: on, B: off)", testResults[1].DisplayName);
+        Assert.AreEqual($"{nameof(this.Two_features_on_off)} (A: off, B: on)", testResults[2].DisplayName);
+        Assert.AreEqual($"{nameof(this.Two_features_on_off)} (A: on, B: on)", testResults[3].DisplayName);
     }
 
     [TestMethod]
@@ -77,7 +87,7 @@ public sealed class FeatureTestMethodAttributeTest
         var attr = new FeatureTestMethodAttribute(onOff: "A", on: "B", off: "C");
 
         var testMethod = new MockTestMethod(this.TestContext);
-        attr.Execute(testMethod);
+        var testResults = attr.Execute(testMethod);
 
         Assert.AreEqual(2, testMethod.Executions.Count);
 
@@ -96,6 +106,10 @@ public sealed class FeatureTestMethodAttributeTest
         Assert.AreEqual(true, testMethod.Executions[1].Features[1].IsOn);
         Assert.AreEqual("C", testMethod.Executions[1].Features[2].Name);
         Assert.AreEqual(false, testMethod.Executions[1].Features[2].IsOn);
+
+        Assert.AreEqual(2, testResults.Length);
+        Assert.AreEqual($"{nameof(this.Single_feature_on_off_and_feature_on_and_feature_off)} (A: off, B: on, C: off)", testResults[0].DisplayName);
+        Assert.AreEqual($"{nameof(this.Single_feature_on_off_and_feature_on_and_feature_off)} (A: on, B: on, C: off)", testResults[1].DisplayName);
     }
 
     [TestMethod]
@@ -103,17 +117,21 @@ public sealed class FeatureTestMethodAttributeTest
     {
         var attr = new FeatureTestMethodAttribute(onOff: "A");
 
-        var testData = new FeatureTestValueAttribute("A", onValue: "On", offValue: "Off");
+        var testData = new FeatureTestValueAttribute("A", onValue: "High", offValue: "Low");
 
-        var testMethod = new MockTestMethod(this.TestContext, new List<Attribute> { testData });
-        attr.Execute(testMethod);
+        var testMethod = new MockTestMethod(this.TestContext, [testData]);
+        var testResults = attr.Execute(testMethod);
 
         Assert.AreEqual(2, testMethod.Executions.Count);
 
         Assert.AreEqual("A", testMethod.Executions[0].Features[0].Name);
         Assert.AreEqual(false, testMethod.Executions[0].Features[0].IsOn);
-        Assert.AreEqual("On", testMethod.Executions[0].Features[0].OnValue);
-        Assert.AreEqual("Off", testMethod.Executions[0].Features[0].OffValue);
+        Assert.AreEqual("High", testMethod.Executions[0].Features[0].OnValue);
+        Assert.AreEqual("Low", testMethod.Executions[0].Features[0].OffValue);
+
+        Assert.AreEqual(2, testResults.Length);
+        Assert.AreEqual($"{nameof(this.Single_feature_on_off_typed)} (A: Low)", testResults[0].DisplayName);
+        Assert.AreEqual($"{nameof(this.Single_feature_on_off_typed)} (A: High)", testResults[1].DisplayName);
     }
 
     [TestMethod]
@@ -123,8 +141,8 @@ public sealed class FeatureTestMethodAttributeTest
 
         var testData = new FeatureTestValueAttribute("A", onValues: ["On1", "On2"], offValue: "Off");
 
-        var testMethod = new MockTestMethod(this.TestContext, new List<Attribute> { testData });
-        attr.Execute(testMethod);
+        var testMethod = new MockTestMethod(this.TestContext, [testData]);
+        var testResults = attr.Execute(testMethod);
 
         Assert.AreEqual(3, testMethod.Executions.Count);
 
@@ -139,6 +157,11 @@ public sealed class FeatureTestMethodAttributeTest
         Assert.AreEqual(true, testMethod.Executions[2].Features[0].IsOn);
         Assert.AreEqual("On2", testMethod.Executions[2].Features[0].OnValue);
         Assert.AreEqual("Off", testMethod.Executions[2].Features[0].OffValue);
+
+        Assert.AreEqual(3, testResults.Length);
+        Assert.AreEqual($"{nameof(this.Single_feature_on_off_typed_multiple_onvalues)} (A: Off)", testResults[0].DisplayName);
+        Assert.AreEqual($"{nameof(this.Single_feature_on_off_typed_multiple_onvalues)} (A: On1)", testResults[1].DisplayName);
+        Assert.AreEqual($"{nameof(this.Single_feature_on_off_typed_multiple_onvalues)} (A: On2)", testResults[2].DisplayName);
     }
 
     public sealed class MockTestMethod : ITestMethod
@@ -147,7 +170,7 @@ public sealed class FeatureTestMethodAttributeTest
         private readonly IList<Attribute> testAttributes;
 
         public MockTestMethod(TestContext testContext)
-            : this(testContext, new List<Attribute>())
+            : this(testContext, [])
         {
         }
 
@@ -157,7 +180,7 @@ public sealed class FeatureTestMethodAttributeTest
             this.testAttributes = testAttributes;
         }
 
-        public IList<MockTestMethodExecution> Executions { get; } = new List<MockTestMethodExecution>();
+        public IList<MockTestMethodExecution> Executions { get; } = [];
 
         public string TestMethodName => this.testContext.TestName!;
 


### PR DESCRIPTION
- Updated to .net 9.
- Changed C# language version to 13.0
- Removed Microsoft.CodeAnalysis.NetAnalyzers package and alwaus using the bundled version.
- Updated all library versions.
- Show on/off features in test's displayname